### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/flag_int.go
+++ b/flag_int.go
@@ -4,6 +4,7 @@ import (
 	"flag"
 	"fmt"
 	"strconv"
+	"math"
 )
 
 // TakesValue returns true of the flag takes a value, otherwise false
@@ -101,6 +102,9 @@ func lookupInt(name string, set *flag.FlagSet) int {
 	if f != nil {
 		parsed, err := strconv.ParseInt(f.Value.String(), 0, 64)
 		if err != nil {
+			return 0
+		}
+		if parsed < math.MinInt || parsed > math.MaxInt {
 			return 0
 		}
 		return int(parsed)


### PR DESCRIPTION
Potential fix for [https://github.com/aperturerobotics/cli/security/code-scanning/2](https://github.com/aperturerobotics/cli/security/code-scanning/2)

To fix the problem, we need to ensure that the value parsed by `strconv.ParseInt` is within the bounds of the `int` type before performing the conversion. This can be done by adding a bounds check to ensure the value is within the range of `int` before converting it. The `math` package provides constants for the minimum and maximum values of `int` on the current platform, which we can use for this check.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
